### PR TITLE
(Ticket 50092) Application should listen on port 8000

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,7 +23,7 @@ class tse_myapplication {
   }
 
   apache::vhost { $::ec2_metadata['local-hostname']:
-    port          => '8080',
+    port          => '8000',
     docroot       => '/var/www/myapplication',
     docroot_owner => 'apache',
     docroot_group => 'apache',


### PR DESCRIPTION
Changes application port to be 8000, previously it was set to port 8080, which conflicted with other services on the host.
